### PR TITLE
Switch to NGINX with routing capability

### DIFF
--- a/anemone-app/Dockerfile
+++ b/anemone-app/Dockerfile
@@ -22,8 +22,11 @@ COPY ./anemone-app ./
 RUN npm run build
 
 # this next stage is the final deliverable. It is just a simple
-# apache2 server with our built application (build/) being served on port 80.
+# nginx server with our built application (build/) being served on port 80.
 # production stage
-FROM httpd:2.4-alpine as production-stage
-COPY --from=build /app/build /usr/local/apache2/htdocs/
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+RUN rm /etc/nginx/conf.d/default.conf
+COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,12 @@
+server {
+  listen 80;
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+  error_page 500 502 503 504 /50x.html;
+  location = /50x.html {
+    root  /usr/share/nginx/html;
+  }
+}


### PR DESCRIPTION
The old Dockerfile didnt account for the React-Router library usage. I noticed a bug on my server that you couldn't actually get to any of the routes such as `/about`

- Notably I added an nginx.conf file which tells nginx to use your new routing. 
- I also switched the final production build from apache to nginx